### PR TITLE
Refactors for better error messages.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +222,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "childe"
 version = "0.1.0"
 dependencies = [
+ "human-panic",
  "swayipc",
  "tokio",
  "trawlcat",
@@ -217,6 +266,12 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concurrent-queue"
@@ -446,6 +501,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "human-panic"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2df2fb4e13fa697d21d93061ebcbbd876f5ef643b48ff59cfab57a726ef140"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "backtrace",
+ "os_info",
+ "serde",
+ "serde_derive",
+ "toml",
+ "uuid",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,6 +578,12 @@ dependencies = [
  "autocfg",
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
@@ -589,6 +666,17 @@ checksum = "44630c059eacfd6e08bdaa51b1db2ce33119caa4ddc1235e923109aa5f25ccb1"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_info"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
+dependencies = [
+ "log",
+ "serde",
+ "winapi",
 ]
 
 [[package]]
@@ -858,6 +946,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,10 +1144,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -1059,6 +1171,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
  "indexmap 2.0.0",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -1133,6 +1247,21 @@ name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+human-panic = "1.2.0"
 swayipc = "3.0.1"
 tokio = "1.32.0"
 trawlcat = "0.2.5"


### PR DESCRIPTION
Tested running this from an x11 session.  While I think the error should occur at sway ipc connection time, this is better than what was before IMO:

```
$ ./target/release/childe 
Well, this is embarrassing.

childe had a problem and crashed. To help us diagnose the problem you can send us a crash report.

We have generated a report file at "/tmp/report-25da5966-c182-4e4a-b374-ed7b09709598.toml". Submit an issue or email with the subject of "childe Crash Report" and include the report as an attachment.


We take privacy seriously, and do not perform any automated error collection. In order to improve the software, we rely on people to submit reports.

Thank you kindly!
```

`/tmp/report-25da5966-c182-4e4a-b374-ed7b09709598.toml`:
```
name = "childe"
operating_system = "Ubuntu 23.04 (lunar) [64-bit]"
crate_version = "0.1.0"
explanation = """
Panic occurred in file 'src/main.rs' at line 13
"""
cause = "Cannot load workspace from resource name: MethodError(OwnedErrorName(ErrorName(Str(Owned(\"org.freedesktop.DBus.Error.ServiceUnknown\")))), Some(\"The name org.regolith.Trawl was not provided by any .service files\"), Msg { type: Error, sender: UniqueName(Str(Borrowed(\"org.freedesktop.DBus\"))), reply-serial: 2, body: Signature(\"s\") })"
method = "Panic"
backtrace = """

   0: 0x555cc0eff673 - core::result::unwrap_failed::h8090202169109f9c
                at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/result.rs:1687
   1: 0x555cc0f85536 - tokio::runtime::park::CachedParkThread::block_on::he8fd065875cc4959
   2: 0x555cc0f862c3 - tokio::runtime::context::runtime::enter_runtime::h477ff283265756cb
   3: 0x555cc0f4545f - tokio::runtime::runtime::Runtime::block_on::hc4a27dbb42fb4ce0
   4: 0x555cc0fa19ba - childe::main::h87984624354bc272
   5: 0x555cc0f60343 - std::sys_common::backtrace::__rust_begin_short_backtrace::hd1c52dceb76fd02f
   6: 0x555cc0f60549 - std::rt::lang_start::{{closure}}::h0225ec4bb79cfadb
   7: 0x555cc1113d1e - core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once::hb1327dc2ef3fecdf
                at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/ops/function.rs:287
                 - std::panicking::try::do_call::h4044173225fe83dd
                at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/panicking.rs:485
                 - std::panicking::try::hd8a722c09d156a53
                at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/panicking.rs:449
                 - std::panic::catch_unwind::hd2ca07971cf0119b
                at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/panic.rs:140
                 - std::rt::lang_start_internal::{{closure}}::h26d89d595cf47b70
                at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/rt.rs:148
                 - std::panicking::try::do_call::hf47aa1aa005e5f1a
                at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/panicking.rs:485
                 - std::panicking::try::h73d246b2423eaf4e
                at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/panicking.rs:449
                 - std::panic::catch_unwind::hbaaeae8f1b2f9915
                at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/panic.rs:140
                 - std::rt::lang_start_internal::h76f3e81e6b8f13f9
                at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/rt.rs:148
   8: 0x555cc0fa1aa5 - main
   9: 0x7f3259823a90 - __libc_start_call_main
                at ./csu/../sysdeps/nptl/libc_start_call_main.h:58
  10: 0x7f3259823b49 - __libc_start_main_impl
                at ./csu/../csu/libc-start.c:360
  11: 0x555cc0eff805 - _start
  12:        0x0 - <unresolved>"""
```